### PR TITLE
feat(scrape): harden RSS scraping + add drift monitoring

### DIFF
--- a/.github/workflows/collate.yml
+++ b/.github/workflows/collate.yml
@@ -33,13 +33,26 @@ jobs:
             python main.py
             echo "Finished running orchestration script."
 
+      - name: Upload scrape metadata artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scrape-metadata
+          path: |
+            data/scrape_metadata/drift_report.md
+            data/scrape_metadata/run_summary.json
+          if-no-files-found: ignore
+
       - name: Commit and push changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/routes.json
+          if [ -f data/scrape_metadata/fingerprints.json ]; then
+            git add data/scrape_metadata/fingerprints.json
+          fi
           if git diff --cached --quiet; then
-            echo "No changes to data/routes.json; skipping commit."
+            echo "No changes to commit; skipping."
             exit 0
           fi
           git commit -m "Updated routes.json"

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 __pycache__
 myenv
 CLAUDE.md
+data/scrape_metadata/drift_report.md
+data/scrape_metadata/run_summary.json
+data/scrape_metadata/fingerprints.prev.json

--- a/src/drift.py
+++ b/src/drift.py
@@ -1,0 +1,298 @@
+# ----- required imports -----
+
+import datetime
+import hashlib
+import io
+import json
+import os
+import re
+from typing import Optional
+from urllib.parse import urlparse
+from xml.etree import ElementTree as ET
+
+from bs4 import BeautifulSoup
+
+# ----- config -----
+
+FINGERPRINT_PATH = "./../data/scrape_metadata/fingerprints.json"
+DRIFT_REPORT_PATH = "./../data/scrape_metadata/drift_report.md"
+HISTORY_DEPTH = 7  # rolling window for entry-count baseline
+SILENT_THRESHOLD_DAYS = 5
+ENTRY_FLOOR_RATIO = 0.4  # flag when entries < 40% of rolling average
+
+# in-memory store, flushed at end of run
+_state: dict = {"feeds": {}}  # url -> record
+_loaded = False
+
+# ----- persistence -----
+
+
+def _load() -> None:
+    global _state, _loaded
+    if _loaded:
+        return
+    if os.path.exists(FINGERPRINT_PATH):
+        try:
+            with open(FINGERPRINT_PATH, "r", encoding="utf-8") as f:
+                _state = json.load(f)
+                if "feeds" not in _state:
+                    _state = {"feeds": {}}
+        except Exception:
+            _state = {"feeds": {}}
+    _loaded = True
+
+
+def _save() -> None:
+    os.makedirs(os.path.dirname(FINGERPRINT_PATH), exist_ok=True)
+    with open(FINGERPRINT_PATH, "w", encoding="utf-8") as f:
+        json.dump(_state, f, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+# ----- fingerprinting -----
+
+
+def _detect_encoding(content_type: str, body: bytes) -> str:
+    if content_type:
+        m = re.search(r"charset=([\w\-]+)", content_type, re.I)
+        if m:
+            return m.group(1).lower()
+    # sniff XML declaration
+    head = body[:200].decode("ascii", errors="ignore")
+    m = re.search(r"encoding=[\"']([\w\-]+)[\"']", head, re.I)
+    if m:
+        return m.group(1).lower()
+    return "utf-8"
+
+
+def _looks_xml(content_type: str, body: bytes) -> bool:
+    if content_type and ("xml" in content_type.lower() or "rss" in content_type.lower()):
+        return True
+    head = body[:512].lstrip()
+    return head.startswith(b"<?xml") or head.startswith(b"<rss") or head.startswith(b"<feed")
+
+
+def _xml_fingerprint(body: bytes) -> dict:
+    try:
+        # ET strips namespaces inconsistently; build a normalized fingerprint
+        parser = ET.XMLParser()
+        root = ET.fromstring(body, parser=parser)
+    except ET.ParseError as e:
+        return {"format": "xml", "parse_error": str(e)}
+
+    def _tag(el):
+        t = el.tag
+        return t.split("}", 1)[1] if "}" in t else t  # strip namespace
+
+    root_tag = _tag(root)
+    root_attrs = sorted(root.attrib.keys())
+
+    # find first entry-like child (item/entry); for RSS the channel wraps items
+    entry = None
+    for el in root.iter():
+        tag = _tag(el)
+        if tag in ("item", "entry"):
+            entry = el
+            break
+
+    first_entry_tag = _tag(entry) if entry is not None else ""
+    first_entry_children = sorted({_tag(c) for c in entry}) if entry is not None else []
+    first_entry_attrs = sorted(entry.attrib.keys()) if entry is not None else []
+
+    # entry count
+    entry_count = sum(1 for el in root.iter() if _tag(el) in ("item", "entry"))
+
+    return {
+        "format": "xml",
+        "root_tag": root_tag,
+        "root_attrs": root_attrs,
+        "first_entry_tag": first_entry_tag,
+        "first_entry_children": first_entry_children,
+        "first_entry_attrs": first_entry_attrs,
+        "entry_count": entry_count,
+    }
+
+
+def _html_fingerprint(body: bytes) -> dict:
+    try:
+        soup = BeautifulSoup(body, "html.parser")
+    except Exception as e:
+        return {"format": "html", "parse_error": str(e)}
+    anchors = soup.find_all("a", href=True)
+    link_count = len(anchors)
+    # top-level structural tags (which sections exist)
+    top_tags = sorted({t.name for t in soup.find_all(True, recursive=False)})
+    # capture distinct class names on anchors (drift signal for templating change)
+    anchor_classes = sorted(
+        {cls for a in anchors[:100] for cls in (a.get("class") or [])}
+    )[:50]
+    return {
+        "format": "html",
+        "top_tags": top_tags,
+        "anchor_count": link_count,
+        "anchor_classes": anchor_classes,
+        "entry_count": link_count,  # alias for floor logic
+    }
+
+
+def _fingerprint(content_type: str, body: bytes) -> dict:
+    fp = _xml_fingerprint(body) if _looks_xml(content_type, body) else _html_fingerprint(body)
+    fp["body_sha256"] = hashlib.sha256(body).hexdigest()
+    fp["encoding"] = _detect_encoding(content_type, body)
+    fp["content_type"] = (content_type or "").split(";")[0].strip().lower()
+    fp["size_bytes"] = len(body)
+    return fp
+
+
+def _structural_keys(fp: dict) -> dict:
+    # subset of fingerprint that defines "schema" — body_sha256/size/encoding excluded
+    keys = ("format", "root_tag", "root_attrs", "first_entry_tag", "first_entry_children",
+            "first_entry_attrs", "top_tags", "anchor_classes", "content_type", "parse_error")
+    return {k: fp[k] for k in keys if k in fp}
+
+
+# ----- public api -----
+
+
+def record_fetch(url: str, body: bytes, content_type: str = "") -> None:
+    """Called from scrapers after a successful fetch. Computes + stores fingerprint."""
+    _load()
+    fp = _fingerprint(content_type, body)
+    rec = _state["feeds"].setdefault(url, {"history": []})
+    rec["current_fingerprint"] = fp
+    rec["last_success_iso"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    # append entry_count to rolling history
+    hist = rec.get("history", [])
+    hist.append({
+        "ts": rec["last_success_iso"],
+        "entry_count": fp.get("entry_count", 0),
+        "structural_sha": _struct_hash(fp),
+    })
+    rec["history"] = hist[-HISTORY_DEPTH:]
+
+
+def _struct_hash(fp: dict) -> str:
+    s = json.dumps(_structural_keys(fp), sort_keys=True)
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:16]
+
+
+def _avg_entry_count(rec: dict) -> Optional[float]:
+    hist = [h["entry_count"] for h in rec.get("history", [])[:-1] if h.get("entry_count")]
+    if len(hist) < 2:
+        return None
+    return sum(hist) / len(hist)
+
+
+def _diff_fingerprint(prev: Optional[dict], curr: dict) -> list:
+    diffs = []
+    if not prev:
+        return diffs
+    prev_s = _structural_keys(prev)
+    curr_s = _structural_keys(curr)
+    for k in set(prev_s) | set(curr_s):
+        if prev_s.get(k) != curr_s.get(k):
+            diffs.append({"field": k, "before": prev_s.get(k), "after": curr_s.get(k)})
+    return diffs
+
+
+# ----- end-of-run reporting -----
+
+
+def finalize(prev_state_path: Optional[str] = None) -> dict:
+    """Write fingerprints.json + drift_report.md; return summary dict.
+
+    prev_state_path lets the caller pin "previous" to the pre-run snapshot for diffing.
+    """
+    _load()
+    prev_state = {}
+    if prev_state_path and os.path.exists(prev_state_path):
+        try:
+            with open(prev_state_path, "r", encoding="utf-8") as f:
+                prev_state = json.load(f)
+        except Exception:
+            prev_state = {}
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    drift_findings = []
+    silent_findings = []
+    floor_findings = []
+
+    for url, rec in _state["feeds"].items():
+        curr_fp = rec.get("current_fingerprint")
+        # silent check (no successful fetch this run + last_success too old)
+        last_iso = rec.get("last_success_iso")
+        if last_iso:
+            try:
+                last_dt = datetime.datetime.fromisoformat(last_iso)
+                age_days = (now - last_dt).days
+                if age_days > SILENT_THRESHOLD_DAYS:
+                    silent_findings.append({"url": url, "age_days": age_days})
+            except Exception:
+                pass
+
+        if not curr_fp:
+            continue
+
+        prev_fp = (
+            prev_state.get("feeds", {}).get(url, {}).get("current_fingerprint")
+            if prev_state else None
+        )
+        diffs = _diff_fingerprint(prev_fp, curr_fp)
+        if diffs:
+            drift_findings.append({"url": url, "diffs": diffs})
+
+        # floor check
+        avg = _avg_entry_count(rec)
+        ec = curr_fp.get("entry_count", 0)
+        if avg is not None and avg >= 5 and ec < avg * ENTRY_FLOOR_RATIO:
+            floor_findings.append({
+                "url": url,
+                "current": ec,
+                "rolling_avg": round(avg, 1),
+            })
+
+    _save()
+    _write_report(drift_findings, silent_findings, floor_findings)
+
+    return {
+        "drift": drift_findings,
+        "silent": silent_findings,
+        "floor": floor_findings,
+        "checked_count": len(_state["feeds"]),
+    }
+
+
+def _write_report(drift, silent, floor) -> None:
+    os.makedirs(os.path.dirname(DRIFT_REPORT_PATH), exist_ok=True)
+    lines = []
+    ts = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    lines.append(f"# Drift Report — {ts}")
+    lines.append("")
+    if not (drift or silent or floor):
+        lines.append("_No drift, silence, or floor violations detected this run._")
+    if drift:
+        lines.append("## Structural drift")
+        for d in drift:
+            lines.append(f"### `{d['url']}`")
+            for c in d["diffs"]:
+                lines.append(f"- **{c['field']}**: `{c['before']}` -> `{c['after']}`")
+            lines.append("")
+    if silent:
+        lines.append("## Silent feeds (>{} days since last success)".format(SILENT_THRESHOLD_DAYS))
+        for s in silent:
+            lines.append(f"- `{s['url']}` — {s['age_days']}d silent")
+        lines.append("")
+    if floor:
+        lines.append("## Entry-count floor breaches")
+        for f in floor:
+            lines.append(f"- `{f['url']}` — {f['current']} entries (rolling avg {f['rolling_avg']})")
+        lines.append("")
+    with open(DRIFT_REPORT_PATH, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def snapshot_previous(dest_path: str) -> None:
+    """Copy current fingerprints.json -> dest so finalize() can diff against pre-run state."""
+    if os.path.exists(FINGERPRINT_PATH):
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        with open(FINGERPRINT_PATH, "rb") as src, open(dest_path, "wb") as dst:
+            dst.write(src.read())

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,20 @@
 # ----- required imports -----
 
+import json
+import os
+import sys
+
 # import local
+import drift
 import superfeed
 import unstructured
 
 # ----- variable initialization -----
 
 OUTPUT_FILENAME = "./../data/routes.json"
+METADATA_DIR = "./../data/scrape_metadata"
+RUN_SUMMARY_PATH = os.path.join(METADATA_DIR, "run_summary.json")
+PREV_SNAPSHOT_PATH = os.path.join(METADATA_DIR, "fingerprints.prev.json")
 RSS_URL_ARRAY = [
     "https://www.singaporelawwatch.sg/Portals/0/RSS/SuperFeed.xml",
     "https://www.singaporelawwatch.sg/Portals/0/RSS/Judgments.xml",
@@ -44,7 +52,27 @@ LOCAL_RSS_ARRAY = [
 
 # ----- execution code -----
 
+def _emit_gh_annotations(drift_summary, outcomes_summary):
+    # GitHub Actions workflow commands; harmless if run outside CI
+    for d in drift_summary.get("drift", []):
+        print(f"::warning title=Feed drift::{d['url']} - {len(d['diffs'])} structural change(s)")
+    for s in drift_summary.get("silent", []):
+        print(f"::warning title=Silent feed::{s['url']} silent for {s['age_days']}d")
+    for f in drift_summary.get("floor", []):
+        print(
+            f"::warning title=Entry-count drop::{f['url']} {f['current']} vs avg {f['rolling_avg']}"
+        )
+    for url in outcomes_summary.get("retried_fail", []):
+        print(f"::warning title=Feed retry exhausted::{url}")
+    for url in outcomes_summary.get("terminal", []):
+        print(f"::warning title=Feed terminal failure::{url}")
+
+
 if __name__ == "__main__":
+    os.makedirs(METADATA_DIR, exist_ok=True)
+    # snapshot pre-run fingerprints so drift.finalize() can diff
+    drift.snapshot_previous(PREV_SNAPSHOT_PATH)
+
     urls = (
         superfeed.remove_duplicates(
             superfeed.flatten(list(map(superfeed.scrape_rss_urls, RSS_URL_ARRAY)))
@@ -57,3 +85,34 @@ if __name__ == "__main__":
         # )
     )
     superfeed.write_urls_to_file(urls, OUTPUT_FILENAME)
+
+    # finalize sidecar artifacts (drift report + run summary)
+    drift_summary = drift.finalize(prev_state_path=PREV_SNAPSHOT_PATH)
+    outcomes = superfeed.OUTCOMES.summary()
+    run_summary = {
+        "items_written": len(urls),
+        "feeds": outcomes,
+        "drift": {
+            "checked_count": drift_summary["checked_count"],
+            "drift_count": len(drift_summary["drift"]),
+            "silent_count": len(drift_summary["silent"]),
+            "floor_count": len(drift_summary["floor"]),
+        },
+    }
+    with open(RUN_SUMMARY_PATH, "w", encoding="utf-8") as f:
+        json.dump(run_summary, f, indent=2, ensure_ascii=False)
+    if os.path.exists(PREV_SNAPSHOT_PATH):
+        os.remove(PREV_SNAPSHOT_PATH)  # transient diff artifact, not committed
+
+    _emit_gh_annotations(drift_summary, outcomes)
+
+    # console summary for local runs
+    print(
+        f"feeds: {len(outcomes['first_try'])} first-try, "
+        f"{len(outcomes['retried_ok'])} retried-ok, "
+        f"{len(outcomes['retried_fail'])} retried-fail, "
+        f"{len(outcomes['terminal'])} terminal; "
+        f"drift: {len(drift_summary['drift'])}, "
+        f"silent: {len(drift_summary['silent'])}, "
+        f"floor: {len(drift_summary['floor'])}"
+    )

--- a/src/retry.py
+++ b/src/retry.py
@@ -1,0 +1,151 @@
+# ----- required imports -----
+
+import functools
+import logging
+import random
+import time
+from typing import Any, Callable, Iterable, Optional, Tuple, Type
+
+import requests
+
+# ----- typed exceptions -----
+
+
+class ScrapeError(Exception):
+    pass  # base
+
+
+class RetryableError(ScrapeError):
+    pass  # transient: network glitch, 5xx, partial XML
+
+
+class TerminalError(ScrapeError):
+    pass  # permanent: 404, 410, robots-disallow
+
+
+# ----- helpers -----
+
+
+def classify_http_status(status_code: int) -> Type[ScrapeError]:
+    if status_code in (404, 410, 451):
+        return TerminalError  # gone/removed/legal
+    if status_code in (401, 403):
+        return TerminalError  # auth/robots — not solvable by retry
+    if 500 <= status_code < 600:
+        return RetryableError
+    if status_code == 429:
+        return RetryableError  # rate limited
+    return TerminalError  # 4xx default: client error
+
+
+def classify_exception(exc: BaseException) -> Type[ScrapeError]:
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return classify_http_status(exc.response.status_code)
+    if isinstance(
+        exc,
+        (
+            requests.ConnectionError,
+            requests.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.ReadTimeout,
+        ),
+    ):
+        return RetryableError
+    if isinstance(exc, (RetryableError, TerminalError)):
+        return type(exc)
+    return TerminalError  # unknown -> treat as terminal (fail fast)
+
+
+# ----- retry decorator -----
+
+
+def retry(
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 30.0,
+    exponential_base: float = 2.0,
+    jitter: bool = True,
+    on_retry: Optional[Callable[[BaseException, int, float], None]] = None,
+    logger: Optional[logging.Logger] = None,
+) -> Callable:
+    """Bounded retry w/ exp backoff + jitter. Retries only RetryableError-classified failures."""
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            _log = logger or logging.getLogger(func.__module__)
+            last_exc: Optional[BaseException] = None
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except BaseException as e:  # classify then decide
+                    last_exc = e
+                    cls = classify_exception(e)
+                    if cls is TerminalError or attempt == max_attempts:
+                        raise
+                    delay = min(
+                        base_delay * (exponential_base ** (attempt - 1)), max_delay
+                    )
+                    if jitter:
+                        delay = delay * (0.75 + random.random() * 0.5)  # +/-25%
+                    _log.warning(
+                        "%s attempt %d/%d failed: %s. Retrying in %.2fs",
+                        func.__name__,
+                        attempt,
+                        max_attempts,
+                        e,
+                        delay,
+                    )
+                    if on_retry:
+                        try:
+                            on_retry(e, attempt, delay)
+                        except Exception:
+                            pass  # callback failure must not stop retry
+                    time.sleep(delay)
+            if last_exc:
+                raise last_exc  # safety net
+            return None
+
+        return wrapper
+
+    return decorator
+
+
+# ----- per-run feed outcome tracker -----
+
+
+class FeedOutcomes:
+    """Aggregates per-feed outcome across a run for summary surfacing."""
+
+    def __init__(self) -> None:
+        self.records: dict = {}  # url -> {status, attempts, error, retries: []}
+
+    def record_attempt(self, url: str, attempt: int, exc: BaseException, delay: float) -> None:
+        rec = self.records.setdefault(url, {"status": "pending", "attempts": 0, "retries": [], "error": ""})
+        rec["retries"].append({"attempt": attempt, "error": f"{type(exc).__name__}: {exc}", "delay_s": round(delay, 2)})
+
+    def record_result(self, url: str, status: str, attempts: int, error: str = "") -> None:
+        rec = self.records.setdefault(url, {"status": "pending", "attempts": 0, "retries": [], "error": ""})
+        rec["status"] = status  # first_try | retried_ok | retried_fail | terminal
+        rec["attempts"] = attempts
+        if error:
+            rec["error"] = error
+
+    def summary(self) -> dict:
+        first_try, retried_ok, retried_fail, terminal = [], [], [], []
+        for url, r in self.records.items():
+            if r["status"] == "first_try":
+                first_try.append(url)
+            elif r["status"] == "retried_ok":
+                retried_ok.append(url)
+            elif r["status"] == "retried_fail":
+                retried_fail.append(url)
+            elif r["status"] == "terminal":
+                terminal.append(url)
+        return {
+            "first_try": first_try,
+            "retried_ok": retried_ok,
+            "retried_fail": retried_fail,
+            "terminal": terminal,
+            "details": self.records,
+        }

--- a/src/superfeed.py
+++ b/src/superfeed.py
@@ -9,6 +9,15 @@ import requests
 from bs4 import BeautifulSoup
 from urllib.parse import unquote
 
+from retry import retry, FeedOutcomes, classify_exception, TerminalError
+
+# module-level outcome tracker; main.py reads this after the run
+OUTCOMES = FeedOutcomes()
+
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+}
+
 # ----- helper functions -----
 
 DESC_MAX = 200  # chars
@@ -57,14 +66,40 @@ def _published_iso(entry):
         return ""
 
 
-def scrape_rss_urls(rss_url):
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    }
-    try:
-        response = requests.get(rss_url, headers=headers, timeout=15)
-        response.raise_for_status()
+def fetch_feed_bytes(rss_url):
+    # network-only step, retried by the retry decorator below
+    resp = requests.get(rss_url, headers=_HEADERS, timeout=15)
+    resp.raise_for_status()
+    body = resp.content
+    if not body or len(body) < 32:
+        # treat near-empty payloads as transient (some CDNs return blank 200s)
+        from retry import RetryableError
 
+        raise RetryableError(f"empty/short body ({len(body)} bytes) from {rss_url}")
+    return resp
+
+
+def scrape_rss_urls(rss_url):
+    attempts = {"n": 0}
+
+    def _on_retry(exc, attempt, delay):
+        OUTCOMES.record_attempt(rss_url, attempt, exc, delay)
+
+    @retry(max_attempts=3, base_delay=1.0, max_delay=30.0, on_retry=_on_retry)
+    def _fetch():
+        attempts["n"] += 1
+        return fetch_feed_bytes(rss_url)
+
+    try:
+        response = _fetch()
+        n = attempts["n"]
+        # publish raw bytes so drift monitor can fingerprint w/o a second fetch
+        try:
+            from drift import record_fetch  # lazy import: drift is optional
+
+            record_fetch(rss_url, response.content, response.headers.get("Content-Type", ""))
+        except Exception:
+            pass  # drift monitoring must never break scraping
         feed = feedparser.parse(response.content)
         items = []
         for entry in feed.entries:
@@ -82,9 +117,17 @@ def scrape_rss_urls(rss_url):
                         "citation": _extract_citation(entry.link, title, desc),
                     }
                 )
+        OUTCOMES.record_result(
+            rss_url, "retried_ok" if n > 1 else "first_try", n
+        )
         return items
-    except Exception:
-        return []
+    except BaseException as e:
+        cls = classify_exception(e)
+        status = "terminal" if cls is TerminalError else "retried_fail"
+        OUTCOMES.record_result(
+            rss_url, status, attempts["n"], error=f"{type(e).__name__}: {e}"
+        )
+        return []  # preserve original contract: failure -> empty list
 
 
 def remove_duplicates(items):

--- a/src/unstructured.py
+++ b/src/unstructured.py
@@ -5,22 +5,42 @@ import requests
 from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
 from urllib.parse import urljoin
 
-from superfeed import _extract_citation
+from superfeed import _extract_citation, OUTCOMES
+from retry import retry, classify_exception, TerminalError, RetryableError
 
 # Suppress warning when parsing XML with HTML parser (intentional for mixed content)
 warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+}
 
 # ----- helper functions -----
 
 
 def extract_urls(url):
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    }
-    try:
-        response = requests.get(url, headers=headers, timeout=15)
-        response.raise_for_status()
+    attempts = {"n": 0}
 
+    def _on_retry(exc, attempt, delay):
+        OUTCOMES.record_attempt(url, attempt, exc, delay)
+
+    @retry(max_attempts=3, base_delay=1.0, max_delay=30.0, on_retry=_on_retry)
+    def _fetch():
+        attempts["n"] += 1
+        r = requests.get(url, headers=_HEADERS, timeout=15)
+        r.raise_for_status()
+        if not r.content or len(r.content) < 32:
+            raise RetryableError(f"empty/short body from {url}")
+        return r
+
+    try:
+        response = _fetch()
+        try:
+            from drift import record_fetch
+
+            record_fetch(url, response.content, response.headers.get("Content-Type", ""))
+        except Exception:
+            pass
         soup = BeautifulSoup(response.content, "html.parser")
         items = []
         seen = set()
@@ -45,6 +65,11 @@ def extract_urls(url):
                 }
             )
 
+        n = attempts["n"]
+        OUTCOMES.record_result(url, "retried_ok" if n > 1 else "first_try", n)
         return items
-    except Exception:
-        return []
+    except BaseException as e:
+        cls = classify_exception(e)
+        status = "terminal" if cls is TerminalError else "retried_fail"
+        OUTCOMES.record_result(url, status, attempts["n"], error=f"{type(e).__name__}: {e}")
+        return []  # preserve original contract


### PR DESCRIPTION
## Summary

Resolves #7 and #8. Backend-only changes — `routes.json` schema is byte-identical, so the consumer app (`sea-kayak-app/`) sees zero behavioral diff.

**#7 — retry semantics (`src/retry.py`)**
- Bounded retry decorator: max 3 attempts, exponential backoff, jitter, 30s ceiling.
- Typed exceptions: `RetryableError` (network glitch, 5xx, 429, sub-32B body) vs `TerminalError` (404/410/451, auth, robots).
- Per-feed `FeedOutcomes` aggregator → emits `run_summary.json` sidecar bucketing feeds into `first_try` / `retried_ok` / `retried_fail` / `terminal`.
- Original `scrape_rss_urls(url) -> list[dict]` and `extract_urls(url) -> list[dict]` contracts preserved (failure → empty list).

**#8 — drift monitoring (`src/drift.py`)**
- Per-feed structural fingerprint: root tag + attrs, first entry tag/children/attrs, content-type, encoding, entry count.
- Both XML (RSS/Atom) and HTML aggregator paths fingerprinted.
- Diff vs **pre-run** snapshot (`fingerprints.prev.json`) so the same run can both detect and persist new fingerprints.
- Rolling 7-run history tracked in `fingerprints.json` (committed) for entry-count floor (`< 40%` of rolling avg flagged) and `>5d` silent-feed detection.
- `data/scrape_metadata/drift_report.md` emitted as workflow artifact; GH Actions `::warning::` annotations emitted inline.

**Workflow (`.github/workflows/collate.yml`)**
- Uploads `drift_report.md` + `run_summary.json` as `scrape-metadata` artifact (`if: always()`).
- Commits `fingerprints.json` alongside `routes.json` (history tracked in repo).
- Drift report + run summary are gitignored (not committed; only artifact-uploaded).

**Non-goals (per issues)**
- No GCS/MongoDB coupling — local sidecar JSON only.
- No job queue — GH Actions cron remains orchestrator.
- No auto-fix on drift — humans review the report.
- No full elefant pipeline dependency — drift monitor is standalone.

## Test plan
- [x] Static AST parse of all `src/*.py` clean
- [x] Unit: `RetryableError` retried up to 3, `TerminalError` raised immediately (no retry)
- [x] Unit: HTTP status classification (404→terminal, 500/429→retryable, 403→terminal)
- [x] Unit: `FeedOutcomes` bucketing
- [x] Unit: Drift XML fingerprint diff (added `<newField>` element → flagged)
- [x] End-to-end smoke: 3 synthetic feeds (good / flaky-2x / 404); flaky recovered, 404 marked terminal, `routes.json` schema unchanged
- [ ] First scheduled CI run on `main` post-merge → verify `scrape-metadata` artifact uploads
- [ ] First run also seeds `data/scrape_metadata/fingerprints.json` (no drift expected since prev=empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)